### PR TITLE
JSON RPC fixes and iterations while implementing Brayns' RocketsPlugin

### DIFF
--- a/apps/server.cpp
+++ b/apps/server.cpp
@@ -178,8 +178,8 @@ int main(int argc, char** argv)
         server.handle(http::Method::GET, "", [&page](const http::Request&) {
             return http::make_ready_response(http::Code::OK, page, "text/html");
         });
-        server.handleText([](const std::string& message) {
-            return "server echo: " + message;
+        server.handleText([](ws::Request request) {
+            return "server echo: " + request.message;
         });
 
         std::cout << "Listening on: http://" << uri << std::endl;

--- a/rockets/CMakeLists.txt
+++ b/rockets/CMakeLists.txt
@@ -39,6 +39,7 @@ set(ROCKETS_PUBLIC_HEADERS
   jsonrpc/emitter.h
   jsonrpc/receiver.h
   jsonrpc/requester.h
+  jsonrpc/responseError.h
   jsonrpc/server.h
   jsonrpc/types.h
   qt/readWriteSocketNotifier.h

--- a/rockets/jsonrpc/client.h
+++ b/rockets/jsonrpc/client.h
@@ -49,9 +49,9 @@ public:
     Client(Communicator& comm)
         : communicator{comm}
     {
-        communicator.handleText([this](std::string message) {
-            if (!processResponse(message))
-                _processNotification(message);
+        communicator.handleText([this](const jsonrpc::Request& request) {
+            if (!processResponse(request.message))
+                _processNotification(request.message);
             return std::string();
         });
     }

--- a/rockets/jsonrpc/client.h
+++ b/rockets/jsonrpc/client.h
@@ -51,7 +51,7 @@ public:
     {
         communicator.handleText([this](const jsonrpc::Request& request) {
             if (!processResponse(request.message))
-                _processNotification(request.message);
+                _processNotification(request);
             return std::string();
         });
     }
@@ -61,9 +61,9 @@ private:
     void _sendNotification(std::string json) final { _send(std::move(json)); }
     /** Requester::_sendRequest */
     void _sendRequest(std::string json) final { _send(std::move(json)); }
-    void _processNotification(const std::string& message)
+    void _processNotification(const jsonrpc::Request& request)
     {
-        process(message, [this](std::string response) {
+        process(request, [this](std::string response) {
             // Note: response should normally be empty, as we don't expect to
             // receive requests from the server (only notifications).
             if (!response.empty())

--- a/rockets/jsonrpc/emitter.cpp
+++ b/rockets/jsonrpc/emitter.cpp
@@ -29,12 +29,12 @@ namespace jsonrpc
 {
 namespace
 {
-json makeNotification(const std::string& method)
+json _makeNotification(const std::string& method)
 {
     return json{{"jsonrpc", "2.0"}, {"method", method}};
 }
 
-json makeNotification(const std::string& method, json&& params)
+json _makeNotification(const std::string& method, json&& params)
 {
     return json{{"jsonrpc", "2.0"},
                 {"method", method},
@@ -44,10 +44,21 @@ json makeNotification(const std::string& method, json&& params)
 
 void Emitter::emit(const std::string& method, const std::string& params)
 {
-    const auto notification =
-        params.empty() ? makeNotification(method)
-                       : makeNotification(method, json::parse(params));
-    _sendNotification(notification.dump(4));
+    const auto notification = params.empty() ? makeNotification(method) :
+                                         makeNotification(method, params);
+    _sendNotification(notification);
 }
+
+std::string Emitter::makeNotification(const std::string &method) const
+{
+    return _makeNotification(method).dump(4);
+}
+
+std::string Emitter::makeNotification(const std::string &method,
+                                      const std::string &params) const
+{
+    return _makeNotification(method, json::parse(params)).dump(4);
+}
+
 }
 }

--- a/rockets/jsonrpc/emitter.h
+++ b/rockets/jsonrpc/emitter.h
@@ -54,6 +54,25 @@ public:
         emit(method, to_json(params));
     }
 
+    /** @return a JSON RPC notification for the given method. */
+    std::string makeNotification(const std::string& method) const;
+
+    /** @return a JSON RPC notification for the given method and params. */
+    std::string makeNotification(const std::string& method,
+                                 const std::string& params) const;
+
+    /**
+     * @return a JSON RPC notification for the given method and templated
+     *         params.
+     */
+    template <typename Params>
+    std::string makeNotification(const std::string& method,
+                                 const Params& params) const
+    {
+        return makeNotification(method, to_json(params));
+    }
+
+
 private:
     virtual void _sendNotification(std::string json) = 0;
 };

--- a/rockets/jsonrpc/receiver.cpp
+++ b/rockets/jsonrpc/receiver.cpp
@@ -164,7 +164,7 @@ Receiver::~Receiver()
 
 void Receiver::connect(const std::string& method, VoidCallback action)
 {
-    bind(method, [action](Request) {
+    bind(method, [action](const Request&) {
         action();
         return Response{"\"OK\""};
     });
@@ -172,7 +172,7 @@ void Receiver::connect(const std::string& method, VoidCallback action)
 
 void Receiver::connect(const std::string& method, NotifyCallback action)
 {
-    bind(method, [action](Request request) {
+    bind(method, [action](const Request& request) {
         action(request);
         return Response{"\"OK\""};
     });
@@ -181,7 +181,7 @@ void Receiver::connect(const std::string& method, NotifyCallback action)
 void Receiver::bind(const std::string& method, ResponseCallback action)
 {
     bindAsync(method,
-              [this, action](Request req, AsyncResponse callback) {
+              [this, action](const Request& req, AsyncResponse callback) {
                   callback(action(req));
               });
 }
@@ -195,12 +195,12 @@ void Receiver::bindAsync(const std::string& method,
     _impl->methods[method] = action;
 }
 
-std::string Receiver::process(Request request)
+std::string Receiver::process(const Request& request)
 {
     return processAsync(request).get();
 }
 
-std::future<std::string> Receiver::processAsync(Request request)
+std::future<std::string> Receiver::processAsync(const Request& request)
 {
     auto promise = std::make_shared<std::promise<std::string>>();
     auto future = promise->get_future();
@@ -211,7 +211,7 @@ std::future<std::string> Receiver::processAsync(Request request)
     return future;
 }
 
-void Receiver::process(Request request, AsyncStringResponse callback)
+void Receiver::process(const Request& request, AsyncStringResponse callback)
 {
     const auto document = json::parse(request.message, nullptr, false);
     if (document.is_object())

--- a/rockets/jsonrpc/receiver.cpp
+++ b/rockets/jsonrpc/receiver.cpp
@@ -126,6 +126,13 @@ public:
             return;
         }
 
+        // No reply for valid "notifications" (requests without an "id")
+        if (id.is_null())
+        {
+            callback(json());
+            return;
+        }
+
         const auto methodName = request["method"].get<std::string>();
         const auto method = methods.find(methodName);
         if (method == methods.end())
@@ -137,13 +144,6 @@ public:
         const auto params = request.find("params") == request.end() ? "" : dump(request["params"]);
         const auto& func = method->second;
         func({params, clientID}, [callback, id](const Response rep) {
-            // No reply for valid "notifications" (requests without an "id")
-            if (id.is_null())
-            {
-                callback(json());
-                return;
-            }
-
             if (rep.error != 0)
                 callback(makeErrorResponse(rep.error, rep.result, id));
             else

--- a/rockets/jsonrpc/receiver.cpp
+++ b/rockets/jsonrpc/receiver.cpp
@@ -42,7 +42,7 @@ const json methodNotFound{{"code", -32601}, {"message", "Method not found"}};
 
 json makeResponse(const std::string& result, const json& id)
 {
-    return json{{"jsonrpc", "2.0"}, {"result", result}, {"id", id}};
+    return json{{"jsonrpc", "2.0"}, {"result", json::parse(result)}, {"id", id}};
 }
 
 json makeErrorResponse(const json& error, const json& id = json())
@@ -81,22 +81,22 @@ inline bool begins_with(const std::string& string, const std::string& other)
 class Receiver::Impl
 {
 public:
-    std::string processBatchBlocking(const json& array)
+    std::string processBatchBlocking(const json& array, const uintptr_t clientID)
     {
         if (array.empty())
             return dump(makeErrorResponse(invalidRequest));
 
-        return dump(processValidBatchBlocking(array));
+        return dump(processValidBatchBlocking(array, clientID));
     }
 
-    json processValidBatchBlocking(const json& array)
+    json processValidBatchBlocking(const json& array, const uintptr_t clientID)
     {
         json responses;
         for (const auto& entry : array)
         {
             if (entry.is_object())
             {
-                const auto response = processCommandBlocking(entry);
+                const auto response = processCommandBlocking(entry, clientID);
                 if (!response.is_null())
                     responses.push_back(response);
             }
@@ -106,29 +106,27 @@ public:
         return responses;
     }
 
-    json processCommandBlocking(const json& request)
+    json processCommandBlocking(const json& request, const uintptr_t clientID)
     {
         auto promise = std::make_shared<std::promise<json>>();
         auto future = promise->get_future();
         auto callback = [promise](json response) {
             promise->set_value(std::move(response));
         };
-        processCommand(request, callback);
+        processCommand(request, clientID, callback);
         return future.get();
     }
 
-    void processCommand(const json& request, std::function<void(json)> callback)
+    void processCommand(const json& request, const uintptr_t clientID, std::function<void(json)> callback)
     {
+        const auto id = request.count("id") ? request["id"] : json();
         if (!_isValidJsonRpcRequest(request))
         {
-            callback(makeErrorResponse(invalidRequest));
+            callback(makeErrorResponse(invalidRequest, id));
             return;
         }
 
-        const auto id = request.count("id") ? request["id"] : json();
         const auto methodName = request["method"].get<std::string>();
-        const auto params = dump(request["params"]);
-
         const auto method = methods.find(methodName);
         if (method == methods.end())
         {
@@ -136,8 +134,9 @@ public:
             return;
         }
 
+        const auto params = request.find("params") == request.end() ? "" : dump(request["params"]);
         const auto& func = method->second;
-        func(params, [callback, id](const Response rep) {
+        func({params, clientID}, [callback, id](const Response rep) {
             // No reply for valid "notifications" (requests without an "id")
             if (id.is_null())
             {
@@ -165,24 +164,24 @@ Receiver::~Receiver()
 
 void Receiver::connect(const std::string& method, VoidCallback action)
 {
-    bind(method, [action](const std::string&) {
+    bind(method, [action](Request) {
         action();
-        return Response{"OK"};
+        return Response{"\"OK\""};
     });
 }
 
 void Receiver::connect(const std::string& method, NotifyCallback action)
 {
-    bind(method, [action](const std::string& request) {
+    bind(method, [action](Request request) {
         action(request);
-        return Response{"OK"};
+        return Response{"\"OK\""};
     });
 }
 
 void Receiver::bind(const std::string& method, ResponseCallback action)
 {
     bindAsync(method,
-              [this, action](const std::string& req, AsyncResponse callback) {
+              [this, action](Request req, AsyncResponse callback) {
                   callback(action(req));
               });
 }
@@ -196,12 +195,12 @@ void Receiver::bindAsync(const std::string& method,
     _impl->methods[method] = action;
 }
 
-std::string Receiver::process(const std::string& request)
+std::string Receiver::process(Request request)
 {
     return processAsync(request).get();
 }
 
-std::future<std::string> Receiver::processAsync(const std::string& request)
+std::future<std::string> Receiver::processAsync(Request request)
 {
     auto promise = std::make_shared<std::promise<std::string>>();
     auto future = promise->get_future();
@@ -212,18 +211,18 @@ std::future<std::string> Receiver::processAsync(const std::string& request)
     return future;
 }
 
-void Receiver::process(const std::string& request, AsyncStringResponse callback)
+void Receiver::process(Request request, AsyncStringResponse callback)
 {
-    const auto document = json::parse(request, nullptr, false);
+    const auto document = json::parse(request.message, nullptr, false);
     if (document.is_object())
     {
         auto stringifyCallback = [callback](const json obj) {
             callback(dump(obj));
         };
-        _impl->processCommand(document, stringifyCallback);
+        _impl->processCommand(document, request.clientID, stringifyCallback);
     }
     else if (document.is_array())
-        callback(_impl->processBatchBlocking(document));
+        callback(_impl->processBatchBlocking(document, request.clientID));
     else
         callback(dump(makeErrorResponse(parseError)));
 }

--- a/rockets/jsonrpc/receiver.h
+++ b/rockets/jsonrpc/receiver.h
@@ -40,10 +40,10 @@ public:
     /** @name Callbacks that can be registered. */
     //@{
     using VoidCallback = std::function<void()>;
-    using NotifyCallback = std::function<void(const std::string&)>;
-    using ResponseCallback = std::function<Response(const std::string&)>;
+    using NotifyCallback = std::function<void(Request)>;
+    using ResponseCallback = std::function<Response(Request)>;
     using DelayedResponseCallback =
-        std::function<void(const std::string&, AsyncResponse)>;
+        std::function<void(Request, AsyncResponse)>;
     //@}
 
     /** Constructor. */
@@ -89,12 +89,12 @@ public:
     template <typename Params>
     void connect(const std::string& method, std::function<void(Params)> action)
     {
-        bind(method, [action](const std::string& request) {
+        bind(method, [action](const Request& request) {
             Params params;
-            if (!from_json(params, request))
+            if (!from_json(params, request.message))
                 return Response::invalidParams();
             action(std::move(params));
-            return Response{"OK"};
+            return Response{"\"OK\""};
         });
     }
 
@@ -120,11 +120,42 @@ public:
     template <typename Params>
     void bind(const std::string& method, std::function<Response(Params)> action)
     {
-        bind(method, [action](const std::string& request) {
+        bind(method, [action](Request request) {
             Params params;
-            if (!from_json(params, request))
+            if (!from_json(params, request.message))
                 return Response::invalidParams();
             return action(std::move(params));
+        });
+    }
+
+    /**
+     * Bind a method to a response callback with templated request parameters
+     * and templated return type.
+     *
+     * The parameters object must be deserializable by a free function:
+     * from_json(Params& object, const std::string& json). The return type must
+     * be serializable by a free function: std::string to_json(const RetVal&)
+     *
+     * @param method to register.
+     * @param action to perform.
+     * @throw std::invalid_argument if the method name starts with "rpc."
+     */
+    template <typename Params, typename RetVal>
+    void bind(const std::string& method, std::function<RetVal(Params)> action)
+    {
+        bind(method, [action](Request request) {
+            Params params;
+            if (!from_json(params, request.message))
+                return Response::invalidParams();
+            try
+            {
+                auto ret = action(std::move(params));
+                return Response{to_json(ret)};
+            }
+            catch (const std::runtime_error& e)
+            {
+                return Response{e.what(), -42};
+            }
         });
     }
 
@@ -152,9 +183,9 @@ public:
                    std::function<void(Params, AsyncResponse)> action)
     {
         bindAsync(method,
-                  [action](const std::string& request, AsyncResponse callback) {
+                  [action](const Request& request, AsyncResponse callback) {
                       Params params;
-                      if (from_json(params, request))
+                      if (from_json(params, request.message))
                           action(std::move(params), callback);
                       else
                           callback(Response::invalidParams());
@@ -164,27 +195,27 @@ public:
     /**
      * Process a JSON-RPC request and block for the result.
      *
-     * @param request string in JSON-RPC 2.0 format.
+     * @param request Request object with message in JSON-RPC 2.0 format.
      * @return json response string in JSON-RPC 2.0 format.
      */
-    std::string process(const std::string& request);
+    std::string process(Request request);
 
     /**
      * Process a JSON-RPC request asynchronously.
      *
-     * @param request string in JSON-RPC 2.0 format.
+     * @param request Request object with message in JSON-RPC 2.0 format.
      * @return future json response string in JSON-RPC 2.0 format.
      */
-    std::future<std::string> processAsync(const std::string& request);
+    std::future<std::string> processAsync(Request request);
 
     /**
      * Process a JSON-RPC request asynchronously.
      *
-     * @param request string in JSON-RPC 2.0 format.
+     * @param request Request object with message in JSON-RPC 2.0 format.
      * @param callback that return a json response string in JSON-RPC 2.0
      *        format upon request completion.
      */
-    void process(const std::string& request, AsyncStringResponse callback);
+    void process(Request request, AsyncStringResponse callback);
 
 private:
     class Impl;

--- a/rockets/jsonrpc/receiver.h
+++ b/rockets/jsonrpc/receiver.h
@@ -151,7 +151,7 @@ public:
                 return Response::invalidParams();
             try
             {
-                RetVal ret = action(std::move(params));
+                const auto& ret = action(std::move(params));
                 return Response{to_json(ret)};
             }
             catch (const response_error& e)

--- a/rockets/jsonrpc/receiver.h
+++ b/rockets/jsonrpc/receiver.h
@@ -151,7 +151,7 @@ public:
                 return Response::invalidParams();
             try
             {
-                const auto ret = action(std::move(params));
+                RetVal ret = action(std::move(params));
                 return Response{to_json(ret)};
             }
             catch (const response_error& e)

--- a/rockets/jsonrpc/responseError.h
+++ b/rockets/jsonrpc/responseError.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2018, EPFL/Blue Brain Project
+ *                     Daniel.Nachbaur@epfl.ch
+ *
+ * This file is part of Rockets <https://github.com/BlueBrain/Rockets>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef ROCKETS_RESPONSEERROR_H
+#define ROCKETS_RESPONSEERROR_H
+
+#include <stdexcept>
+
+namespace rockets
+{
+namespace jsonrpc
+{
+class response_error : public std::runtime_error
+{
+public:
+    response_error(const std::string& what, const int code_)
+        : std::runtime_error(what)
+        , code(code_)
+    {}
+
+    const int code;
+};
+}
+}
+
+#endif

--- a/rockets/jsonrpc/server.h
+++ b/rockets/jsonrpc/server.h
@@ -52,7 +52,7 @@ public:
     {
         communicator.handleText(
             [this](ws::Request request, ws::ResponseCallback callback) {
-                process({std::move(request.message), request.clientID}, callback);
+                process(std::move(request), callback);
             });
     }
 

--- a/rockets/jsonrpc/server.h
+++ b/rockets/jsonrpc/server.h
@@ -51,8 +51,8 @@ public:
         : communicator{server}
     {
         communicator.handleText(
-            [this](std::string message, ws::ResponseCallback callback) {
-                process(std::move(message), callback);
+            [this](ws::Request request, ws::ResponseCallback callback) {
+                process({std::move(request.message), request.clientID}, callback);
             });
     }
 

--- a/rockets/jsonrpc/types.h
+++ b/rockets/jsonrpc/types.h
@@ -23,10 +23,14 @@
 #include <functional>
 #include <string>
 
+#include <rockets/ws/types.h>
+
 namespace rockets
 {
 namespace jsonrpc
 {
+using ws::Request;
+
 /**
  * Response to a well-formed RPC request.
  */

--- a/rockets/server.cpp
+++ b/rockets/server.cpp
@@ -200,7 +200,7 @@ void Server::broadcastText(const std::string &message, std::set<uintptr_t> filte
     std::lock_guard<std::mutex> lock{_impl->wsConnectionsMutex};
     for (auto& connection : _impl->wsConnections)
     {
-        if(filter.find(reinterpret_cast<uintptr_t>(&connection)) == filter.end())
+        if(filter.find(reinterpret_cast<uintptr_t>(&connection.second)) == filter.end())
             connection.second.enqueueText(message);
     }
     _impl->requestBroadcast();

--- a/rockets/server.cpp
+++ b/rockets/server.cpp
@@ -195,6 +195,17 @@ void Server::broadcastText(const std::string& message)
     _impl->requestBroadcast();
 }
 
+void Server::broadcastText(const std::string &message, std::set<uintptr_t> filter)
+{
+    std::lock_guard<std::mutex> lock{_impl->wsConnectionsMutex};
+    for (auto& connection : _impl->wsConnections)
+    {
+        if(filter.find(reinterpret_cast<uintptr_t>(&connection)) == filter.end())
+            connection.second.enqueueText(message);
+    }
+    _impl->requestBroadcast();
+}
+
 void Server::broadcastBinary(const char* data, const size_t size)
 {
     std::lock_guard<std::mutex> lock{_impl->wsConnectionsMutex};

--- a/rockets/server.h
+++ b/rockets/server.h
@@ -28,6 +28,8 @@
 #include <rockets/socketBasedInterface.h>
 #include <rockets/ws/types.h>
 
+#include <set>
+
 namespace rockets
 {
 /**
@@ -175,6 +177,9 @@ public:
 
     /** Broadcast a text message to all websocket clients. */
     ROCKETS_API void broadcastText(const std::string& message);
+
+    /** Broadcast a text message to all websocket clients, except the filtered ones. */
+    ROCKETS_API void broadcastText(const std::string& message, std::set<uintptr_t> filter);
 
     /** Broadcast a binary message to all websocket clients. */
     ROCKETS_API void broadcastBinary(const char* data, size_t size);

--- a/rockets/ws/messageHandler.cpp
+++ b/rockets/ws/messageHandler.cpp
@@ -46,10 +46,10 @@ void MessageHandler::handleMessage(Connection& connection, const char* data,
     if (format == Format::text)
     {
         if (callbackText)
-            response = callbackText(std::move(_buffer));
+            response = callbackText({std::move(_buffer), reinterpret_cast<uintptr_t>(&connection) });
         else if (callbackTextAsync)
         {
-            callbackTextAsync(std::move(_buffer),
+            callbackTextAsync({std::move(_buffer), reinterpret_cast<uintptr_t>(&connection) },
                               [&connection](std::string reply)
             {
                 if (!reply.empty())
@@ -59,7 +59,7 @@ void MessageHandler::handleMessage(Connection& connection, const char* data,
         }
     }
     else if (format == Format::binary && callbackBinary)
-        response = callbackBinary(std::move(_buffer));
+        response = callbackBinary({std::move(_buffer), reinterpret_cast<uintptr_t>(&connection)});
 
     if (response.format == Format::unspecified)
         response.format = format;

--- a/rockets/ws/messageHandler.cpp
+++ b/rockets/ws/messageHandler.cpp
@@ -61,8 +61,8 @@ void MessageHandler::handleMessage(Connection& connection, const char* data,
     }
     else if (format == Format::binary && callbackBinary)
         response = callbackBinary({std::move(_buffer), clientID});
-    else
-        _buffer.clear();
+
+    _buffer.clear();
 
     if (response.format == Format::unspecified)
         response.format = format;

--- a/rockets/ws/messageHandler.cpp
+++ b/rockets/ws/messageHandler.cpp
@@ -61,6 +61,8 @@ void MessageHandler::handleMessage(Connection& connection, const char* data,
     }
     else if (format == Format::binary && callbackBinary)
         response = callbackBinary({std::move(_buffer), clientID});
+    else
+        _buffer.clear();
 
     if (response.format == Format::unspecified)
         response.format = format;

--- a/rockets/ws/messageHandler.cpp
+++ b/rockets/ws/messageHandler.cpp
@@ -41,15 +41,16 @@ void MessageHandler::handleMessage(Connection& connection, const char* data,
     if (connection.getChannel().currentMessageHasMore())
         return;
 
+    const auto clientID = reinterpret_cast<uintptr_t>(&connection);
     const Format format = connection.getChannel().getCurrentMessageFormat();
     Response response;
     if (format == Format::text)
     {
         if (callbackText)
-            response = callbackText({std::move(_buffer), reinterpret_cast<uintptr_t>(&connection) });
+            response = callbackText({std::move(_buffer), clientID });
         else if (callbackTextAsync)
         {
-            callbackTextAsync({std::move(_buffer), reinterpret_cast<uintptr_t>(&connection) },
+            callbackTextAsync({std::move(_buffer), clientID },
                               [&connection](std::string reply)
             {
                 if (!reply.empty())
@@ -59,7 +60,7 @@ void MessageHandler::handleMessage(Connection& connection, const char* data,
         }
     }
     else if (format == Format::binary && callbackBinary)
-        response = callbackBinary({std::move(_buffer), reinterpret_cast<uintptr_t>(&connection)});
+        response = callbackBinary({std::move(_buffer), clientID});
 
     if (response.format == Format::unspecified)
         response.format = format;
@@ -72,7 +73,8 @@ void MessageHandler::handleOpenConnection(Connection& connection)
     if (!callbackOpen)
         return;
 
-    auto responses = callbackOpen();
+    const auto clientID = reinterpret_cast<uintptr_t>(&connection);
+    auto responses = callbackOpen(clientID);
     for (auto& response : responses)
         _sendResponse(response, connection);
 }
@@ -88,7 +90,8 @@ void MessageHandler::handleCloseConnection(Connection& connection)
     if (!callbackClose)
         return;
 
-    auto responses = callbackClose();
+    const auto clientID = reinterpret_cast<uintptr_t>(&connection);
+    auto responses = callbackClose(clientID);
     for (auto& response : responses)
         _sendResponse(response, connection);
 }

--- a/rockets/ws/types.h
+++ b/rockets/ws/types.h
@@ -55,8 +55,13 @@ enum class Recipient
  */
 struct Request
 {
-    Request(std::string message_, const uintptr_t clientID_ = 0)
+    Request(const std::string& message_, const uintptr_t clientID_ = 0)
         : message(message_)
+        , clientID(clientID_)
+    {}
+
+    Request(std::string&& message_, const uintptr_t clientID_ = 0)
+        : message(std::move(message_))
         , clientID(clientID_)
     {}
 
@@ -100,7 +105,7 @@ using MessageCallback = std::function<Response(Request)>;
 using MessageCallbackAsync = std::function<void(Request, ResponseCallback)>;
 
 /** Websocket callback for handling connection (open/close) messages. */
-using ConnectionCallback = std::function<std::vector<Response>()>;
+using ConnectionCallback = std::function<std::vector<Response>(uintptr_t)>;
 }
 }
 

--- a/rockets/ws/types.h
+++ b/rockets/ws/types.h
@@ -51,7 +51,21 @@ enum class Recipient
 };
 
 /**
- * A response followed after an incoming message/request.
+ * A request from a client during handleText()/handleBinary().
+ */
+struct Request
+{
+    Request(std::string message_, const uintptr_t clientID_ = 0)
+        : message(message_)
+        , clientID(clientID_)
+    {}
+
+    std::string message;
+    const uintptr_t clientID;
+};
+
+/**
+ * A response followed after an incoming request.
  */
 struct Response
 {
@@ -79,11 +93,11 @@ struct Response
 /** Callback for asynchronously responding to a message. */
 using ResponseCallback = std::function<void(std::string)>;
 
-/** WebSocket callback for handling text / binary messages. */
-using MessageCallback = std::function<Response(std::string)>;
+/** WebSocket callback for handling requests of text / binary messages. */
+using MessageCallback = std::function<Response(Request)>;
 
-/** Callback for handling messge with delayed response. */
-using MessageCallbackAsync = std::function<void(std::string, ResponseCallback)>;
+/** Callback for handling request with delayed response. */
+using MessageCallbackAsync = std::function<void(Request, ResponseCallback)>;
 
 /** Websocket callback for handling connection (open/close) messages. */
 using ConnectionCallback = std::function<std::vector<Response>()>;

--- a/tests/websockets.cpp
+++ b/tests/websockets.cpp
@@ -478,3 +478,35 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(server_unspecified_format_response, F,
     BOOST_CHECK(F::receivedConnect);
     BOOST_CHECK(!F::receivedConnectReply);
 }
+
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(text_binary_exchange_with_unhandled_binary, F,
+                                 Fixtures, F)
+{
+    F::client1.handleText([&](const ws::Request& request) {
+        BOOST_CHECK_EQUAL(request.message, "bla");
+        return "";
+    });
+
+    connect(F::client1, F::server);
+
+    F::server.broadcastText("bla");
+    F::server.broadcastBinary("hello", 5);
+    F::server.broadcastText("bla");
+    F::processAllClients(F::server);
+}
+
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(text_binary_exchange_with_unhandled_text, F,
+                                 Fixtures, F)
+{
+    F::client1.handleBinary([&](const ws::Request& request) {
+        BOOST_CHECK_EQUAL(request.message, "hello");
+        return "";
+    });
+
+    connect(F::client1, F::server);
+
+    F::server.broadcastBinary("hello", 5);
+    F::server.broadcastText("bla");
+    F::server.broadcastBinary("hello", 5);
+    F::processAllClients(F::server);
+}


### PR DESCRIPTION
* fix double JSON encoding for responses
* fix requests w/o parameters
* fix missing ID for error responses to requests
* expose Emitter::makeNotification
* add ws::Request to transport clientID
* add filtering to broadcastText()